### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete regular expression for hostnames

### DIFF
--- a/google/genai/_replay_api_client.py
+++ b/google/genai/_replay_api_client.py
@@ -139,7 +139,7 @@ def _redact_request_url(url: str) -> str:
       result,
   )
   result = re.sub(
-      r'https://generativelanguage.googleapis.com/[^/]+',
+      r'https://generativelanguage\.googleapis\.com/[^/]+',
       '{MLDEV_URL_PREFIX}',
       result,
   )


### PR DESCRIPTION
Potential fix for [https://github.com/Marco1553/python-genai/security/code-scanning/6](https://github.com/Marco1553/python-genai/security/code-scanning/6)

To fix the problem, the regular expression should escape the `.` character in the hostname, so it matches a literal dot rather than any character. Specifically, in the pattern on line 142, change `https://generativelanguage.googleapis.com/[^/]+` to `https://generativelanguage\.googleapis\.com/[^/]+` (note the backslashes before each `.`). This will ensure that it only matches URLs using the literal subdomain and domain, and not variants with other characters.

Edit the file `google/genai/_replay_api_client.py`, at the location of this regular expression in the `_redact_request_url` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
