### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete regular expression for hostnames

### DIFF
--- a/google/genai/_replay_api_client.py
+++ b/google/genai/_replay_api_client.py
@@ -134,7 +134,7 @@ def _redact_request_url(url: str) -> str:
       result,
   )
   result = re.sub(
-      r'.*aiplatform.googleapis.com/[^/]+/',
+      r'.*aiplatform\.googleapis\.com/[^/]+/',
       '{VERTEX_URL_PREFIX}/',
       result,
   )


### PR DESCRIPTION
Potential fix for [https://github.com/Marco1553/python-genai/security/code-scanning/5](https://github.com/Marco1553/python-genai/security/code-scanning/5)

To fix the problem, we should escape the `.` in the regular expression at line 137 so that only domains of the form `[anything]aiplatform.googleapis.com` are matched, and not unintended hosts such as `XaiplatformZgoogleapis.com`. Specifically, change `.*aiplatform.googleapis.com/[^/]+/` to `.*aiplatform\.googleapis\.com/[^/]+/`. This entails editing the literal string in the regex used in `re.sub` at line 137 of `google/genai/_replay_api_client.py`. No additional imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
